### PR TITLE
Adding Jobspresso to the list of remote job boards

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ A curated list of awesome [remote working](http://en.wikipedia.org/wiki/Telecomm
   1. [Remote Hackers](http://remotehackers.com/)
   1. [weworkremotely.com](https://weworkremotely.com/)
   1. [WFH.io](https://www.wfh.io/)
-
+  1. [Jobspresso](http://jobspresso.co)
+  
 ## Newsletters
   1. [Working Nomads](http://workingnomads.co/) - job posts
   1. [Remote Digest](http://remotedigest.com/) - job posts


### PR DESCRIPTION
Jobspresso is a recent job board that is focused solely in remote opportunities
